### PR TITLE
Feat: Added a button to process sheet ingestion remotely

### DIFF
--- a/src/pages/IngestionPage/IngestionPage.tsx
+++ b/src/pages/IngestionPage/IngestionPage.tsx
@@ -70,6 +70,15 @@ function IngestionPage() {
     });
   };
 
+  const processSheetIngestion = async () => {
+    try {
+      const response = await axios.post(`${getApiUrl()}/sheet-ingestion`, {});
+      console.log('Sheet ingestion initiated:', response.data);
+    } catch (error) {
+      console.error('Error initiating sheet ingestion:', error);
+    }
+  };
+
   return (
     <BasePage>
       <Box>
@@ -104,9 +113,14 @@ function IngestionPage() {
           Processed:{' '}
           {files?.filter((file) => file.status === 'Processed').length}
         </Typography>
-        <Button variant="contained" onClick={processAllFiles}>
-          Queue All Unprocessed
-        </Button>
+        <Stack direction="row" spacing={2} sx={{ marginBottom: '16px' }}>
+          <Button variant="contained" onClick={processAllFiles}>
+            Queue All Unprocessed
+          </Button>
+          <Button variant="contained" onClick={processSheetIngestion} color="secondary">
+            Process Sheet Ingestion
+          </Button>
+        </Stack>
         <Box sx={{ marginTop: '16px' }}>
           {files?.map((file) => (
             <Accordion


### PR DESCRIPTION
Fixes #21 
Added a button that automatically processes data track sheet ingestion. 
<img width="1468" alt="Screenshot 2025-03-25 at 2 33 50 PM" src="https://github.com/user-attachments/assets/2e700a22-d7e9-45a1-88e5-306573e9ef08" />
