### PR TITLE
Feat: Added helper text to provide context on IGV page

### DIFF
--- a/src/pages/IGVPage/IGVPage.tsx
+++ b/src/pages/IGVPage/IGVPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Box, Paper, Button } from '@mui/material';
+import { Box, Paper, Button, Typography } from '@mui/material';
 import IGVBrowser from '../../components/IGVBrowser';
 import { useQuery } from '@apollo/client';
 import { DataTracksTableDocument, DataTracksTableQuery } from '../../__generated__/graphql';
@@ -173,6 +173,9 @@ const IGVPage = () => {
                 <Button onClick={removeAllTracks} variant="contained" color="secondary">
                   Remove All Tracks
                 </Button>
+                <Typography variant="body2" sx={{ mt: 1, color: 'text.secondary' }}>
+                  Select cell types and click 'Add Tracks' to view E2G predictions in the IGV browser
+                </Typography>
               </Box>
               <Paper sx={{ height: 'fit-content', overflow: 'auto' }}>
                 <DataTable


### PR DESCRIPTION
Fixes #17 
Added text that provides more information on how to use the Add Tracks button.
<img width="1470" alt="Screenshot 2025-03-25 at 2 43 35 PM" src="https://github.com/user-attachments/assets/a0a4faa6-35b5-4cba-bd92-2434d3c9d864" />
